### PR TITLE
Removes assets.enabled for dev, cleans mobile nav

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,9 @@ html {
   p {
     font-size: 10px;
   }
+  .side-cta-container {
+    font-size: larger;
+  }
 }
 // phones
 @media screen and (min-width: 320px) {
@@ -57,6 +60,18 @@ html {
   }
   .socials {
     gap: 5vh;
+  }
+  .side-cta-container {
+    a {
+      font-size: medium;
+    }
+  }
+
+  .svcs {
+    display: block;
+  }
+  .abt {
+    display: block;
   }
 }
 
@@ -169,5 +184,3 @@ html {
 }
 
 // test
-
-

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -15,6 +15,7 @@
   a {
     text-decoration: none;
     color: white;
+    font-size: large;
     &:hover {
       opacity: 0.8;
     }
@@ -26,6 +27,18 @@
   align-items: center;
   width: 33%;
   gap: 3.5%;
+}
+.ptf {
+  margin-right: 4vw;
+}
+.ctct {
+  margin-left: 4vw;
+}
+.svcs {
+  display: none;
+}
+.abt {
+  display: none;
 }
 
 .left-cta-container {

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar-container" data-controller="navbar" data-navbar-target="navcontainer" data-action="scroll@window->navbar#update">
   <div class="side-cta-container left-cta-container">
-    <a href="#about" data-controller="scroll-to">About</a>
-    <a href="#portfolio" data-controller="scroll-to">Portfolio</a>
+    <a class="abt" href="#about" data-controller="scroll-to">About</a>
+    <a class="ptf" href="#portfolio" data-controller="scroll-to">Portfolio</a>
     <h1 class="navbar-name">Arnold</h1>
   </div>
   <svg class="navbar-logo" preserveAspectRadio="xMinYMin meet" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -12,7 +12,7 @@
 
   <div class="side-cta-container right-cta-container">
     <h1 class="navbar-name">C. Jones</h1>
-    <a href="#footer" data-controller="scroll-to">Contact</a>
-    <a href="#services" data-controller="scroll-to">Services</a>
+    <a class="ctct" href="#footer" data-controller="scroll-to">Contact</a>
+    <a class="svcs" href="#services" data-controller="scroll-to">Services</a>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,8 +15,8 @@ module Portfoliosite
     end
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-    config.assets.paths << "#{Rails.root}/app/assets/videos"
-    config.assets.enabled = true
+    # config.assets.paths << "#{Rails.root}/app/assets/videos"
+    # config.assets.enabled = true
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
On mobile, the navbar now shows only the two pertinent items, portfolio and contact. it displays them larger for readability.

In development build, application.rb no longer has config.assets.enabled = true. 

This is so that assets will precompile cleanly on refresh.
A addition to the assets path # config.assets.paths << "#{Rails.root}/app/assets/videos" was commented out, as this directory no longer exists, due to no videos being in the asset pipeline.

