### PR TITLE
Makes P tags a larger font size on mob

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,7 +21,7 @@ html {
   font-size: 16px;
   --max-width:1600px;
   p {
-    font-size: 10px;
+    font-size: 15px;
   }
   .side-cta-container {
     font-size: larger;
@@ -33,7 +33,7 @@ html {
     h1 {
       font-size: calc(24px + 6 * ((100vw - 320px) / 680));
     }
-    font-size: calc(10px + 6 * ((100vw - 320px) / 680));
+    font-size: calc(15px + 6 * ((100vw - 320px) / 680));
   }
   .home-banner-text {
     padding-right: 2%;

--- a/app/assets/stylesheets/components/_point_banner.scss
+++ b/app/assets/stylesheets/components/_point_banner.scss
@@ -50,7 +50,7 @@
 @media screen and (min-height:500px) {
 
   .point-banner {
-    height: 30vh;
+    height: fit-content;
   }
 
   .point-head {


### PR DESCRIPTION
P tags were coming out too small on mobile version. Appears fine when using browser simulations of mobile site, but not on an actual phone. Will be using localtunnel in future.