### PR TITLE
Makes bolder fonts

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@ html {
   --max-width:1600px;
   p {
     font-size: 15px;
+    text-shadow:.4px .4px $prussian-blue;
   }
   .side-cta-container {
     font-size: larger;
@@ -258,5 +259,3 @@ html {
     bottom: 1.8rem;
   }
 }
-
-// test

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,8 +21,8 @@ html {
   font-size: 16px;
   --max-width:1600px;
   p {
-    font-size: 15px;
     text-shadow:.4px .4px $prussian-blue;
+    font-size: 15px;
   }
   .side-cta-container {
     font-size: larger;


### PR DESCRIPTION
Fonts displayed on the white background of the page were displaying too thin, not contrasting enough due to font's natural character width. There was no 'bold' or more visible font available, and as such the best alternative rather than changing font entirely was to add some text shadow on smaller fonts laying in front of the areas of white background. gives a bold effect.